### PR TITLE
dp: cap the per-thread DP scratch cache to bound peak RSS

### DIFF
--- a/rammap-core/src/align/dp/common.rs
+++ b/rammap-core/src/align/dp/common.rs
@@ -360,6 +360,32 @@ thread_local! {
     pub(super) static DP_MEM_CACHE: Cell<Option<(*mut u8, std::alloc::Layout)>> = const { Cell::new(None) };
 }
 
+/// Upper bound (bytes) on the size of a DP scratch buffer that the per-thread
+/// [`DP_MEM_CACHE`] is allowed to retain between alignments. Buffers larger than
+/// this are freed back to the OS on drop instead of cached.
+///
+/// The splice DP is unbanded, so a single large gap-fill segment needs
+/// `O((qlen+tlen)·min(qlen,tlen))` bytes — hundreds of MB for the rare read with
+/// a big unaligned gap. Without a cap, that one-off high-water mark is pinned per
+/// worker thread for the rest of the run; at high thread counts the sum dominates
+/// peak RSS (the genome-mode regression vs minimap2, whose `km`/`cap_kalloc` arena
+/// is bounded the same way). The common case (almost all buffers are well under
+/// the cap) stays cached and churn-free; only the rare giant buffers reallocate.
+///
+/// Override with `RAMMAP_DP_CACHE_CAP_MB` (megabytes; `0` disables the cap).
+fn dp_cache_cap_bytes() -> usize {
+    use std::sync::OnceLock;
+    static CAP: OnceLock<usize> = OnceLock::new();
+    *CAP.get_or_init(|| {
+        const DEFAULT_MB: usize = 128;
+        let mb = std::env::var("RAMMAP_DP_CACHE_CAP_MB")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_MB);
+        mb.saturating_mul(1_048_576)
+    })
+}
+
 pub(super) struct AlignedMemory {
     ptr: *mut u8,
     layout: std::alloc::Layout,
@@ -397,10 +423,23 @@ impl AlignedMemory {
 
 impl Drop for AlignedMemory {
     fn drop(&mut self) {
+        let cap = dp_cache_cap_bytes();
+        if cap != 0 && self.layout.size() > cap {
+            // Oversized one-off buffer (rare large gap-fill): free it back to the
+            // OS rather than pinning it per-thread for the rest of the run. This
+            // bounds the cached high-water mark, the cap_kalloc analog.
+            unsafe { std::alloc::dealloc(self.ptr, self.layout); }
+            self.ptr = std::ptr::null_mut();
+            return;
+        }
         // Return to cache instead of deallocating. Keep the larger allocation
-        // if the cache already has one (high-water-mark strategy).
+        // if the cache already has one (high-water-mark strategy). If the cache
+        // already holds a (cap-bounded) buffer, free this one to avoid leaking
+        // the displaced allocation.
         DP_MEM_CACHE.with(|cache| {
-            cache.set(Some((self.ptr, self.layout)));
+            if let Some((old_ptr, old_layout)) = cache.replace(Some((self.ptr, self.layout))) {
+                unsafe { std::alloc::dealloc(old_ptr, old_layout); }
+            }
         });
         // Null out to prevent use-after-free if Drop is somehow called twice
         self.ptr = std::ptr::null_mut();

--- a/rammap-core/src/align/dp/common.rs
+++ b/rammap-core/src/align/dp/common.rs
@@ -360,31 +360,16 @@ thread_local! {
     pub(super) static DP_MEM_CACHE: Cell<Option<(*mut u8, std::alloc::Layout)>> = const { Cell::new(None) };
 }
 
-/// Upper bound (bytes) on the size of a DP scratch buffer that the per-thread
-/// [`DP_MEM_CACHE`] is allowed to retain between alignments. Buffers larger than
-/// this are freed back to the OS on drop instead of cached.
-///
-/// The splice DP is unbanded, so a single large gap-fill segment needs
-/// `O((qlen+tlen)·min(qlen,tlen))` bytes — hundreds of MB for the rare read with
-/// a big unaligned gap. Without a cap, that one-off high-water mark is pinned per
-/// worker thread for the rest of the run; at high thread counts the sum dominates
-/// peak RSS (the genome-mode regression vs minimap2, whose `km`/`cap_kalloc` arena
-/// is bounded the same way). The common case (almost all buffers are well under
-/// the cap) stays cached and churn-free; only the rare giant buffers reallocate.
-///
-/// Override with `RAMMAP_DP_CACHE_CAP_MB` (megabytes; `0` disables the cap).
-fn dp_cache_cap_bytes() -> usize {
-    use std::sync::OnceLock;
-    static CAP: OnceLock<usize> = OnceLock::new();
-    *CAP.get_or_init(|| {
-        const DEFAULT_MB: usize = 128;
-        let mb = std::env::var("RAMMAP_DP_CACHE_CAP_MB")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(DEFAULT_MB);
-        mb.saturating_mul(1_048_576)
-    })
-}
+// The per-thread DP scratch cache retains each thread's high-water-mark buffer.
+// The splice DP is unbanded, so a single large gap-fill segment needs
+// `O((qlen+tlen)·min(qlen,tlen))` bytes — hundreds of MB for the rare read with a
+// big unaligned gap. Without a cap, that one-off high-water mark is pinned per
+// worker thread for the rest of the run; at high thread counts the sum dominates
+// peak RSS (the genome-mode regression vs minimap2, whose `km`/`cap_kalloc` arena
+// is bounded the same way). The cap (see `super::dp_cache_cap_bytes` /
+// `super::set_dp_cache_cap_mb`) frees buffers larger than the bound on drop; the
+// common case (almost all buffers well under the cap) stays cached and churn-free.
+use super::dp_cache_cap_bytes;
 
 pub(super) struct AlignedMemory {
     ptr: *mut u8,

--- a/rammap-core/src/align/dp/mod.rs
+++ b/rammap-core/src/align/dp/mod.rs
@@ -61,11 +61,16 @@ static DP_CACHE_CAP_BYTES: AtomicUsize = AtomicUsize::new(usize::MAX);
 /// [`set_dp_cache_cap_mb`] nor `RAMMAP_DP_CACHE_CAP_MB` is set.
 pub const DEFAULT_DP_CACHE_CAP_MB: usize = 128;
 
+/// Pass to [`set_dp_cache_cap_mb`] (or set `RAMMAP_DP_CACHE_CAP_MB=0`) to disable the
+/// cap entirely, restoring the original unbounded high-water-mark caching behavior —
+/// each thread retains its largest-ever DP buffer for the lifetime of the run.
+pub const DP_CACHE_UNBOUNDED: usize = 0;
+
 /// Set the per-process cap, in megabytes, on the DP scratch buffer that each worker
 /// thread's `DP_MEM_CACHE` retains between alignments. Buffers larger than the cap are
 /// freed back to the OS on drop instead of cached, bounding peak RSS at high thread
-/// counts (the minimap2 `cap_kalloc` analog). `0` disables the cap entirely, restoring
-/// unbounded high-water-mark caching.
+/// counts (the minimap2 `cap_kalloc` analog). Pass [`DP_CACHE_UNBOUNDED`] (`0`) to
+/// disable the cap entirely, restoring unbounded high-water-mark caching.
 ///
 /// Overrides both the [`DEFAULT_DP_CACHE_CAP_MB`] default and the `RAMMAP_DP_CACHE_CAP_MB`
 /// environment variable for all subsequent alignments on every thread. Process-global,
@@ -176,8 +181,9 @@ mod tests {
         set_dp_cache_cap_mb(64);
         assert_eq!(dp_cache_cap_bytes(), 64 << 20);
 
-        set_dp_cache_cap_mb(0); // 0 disables the cap entirely
+        set_dp_cache_cap_mb(DP_CACHE_UNBOUNDED); // disables the cap entirely
         assert_eq!(dp_cache_cap_bytes(), 0);
+        assert_eq!(DP_CACHE_UNBOUNDED, 0);
 
         set_dp_cache_cap_mb(DEFAULT_DP_CACHE_CAP_MB);
         assert_eq!(dp_cache_cap_bytes(), DEFAULT_DP_CACHE_CAP_MB << 20);

--- a/rammap-core/src/align/dp/mod.rs
+++ b/rammap-core/src/align/dp/mod.rs
@@ -18,7 +18,7 @@ mod dual;
 mod splice;
 mod lw;
 
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 
 /// Per-process cap on SIMD width.
 ///
@@ -49,6 +49,48 @@ static SIMD_CAP: AtomicU8 = AtomicU8::new(SimdCap::Auto as u8);
 /// process-global; reset to `Auto` if switching back to a DP-heavy preset.
 pub fn set_simd_cap(cap: SimdCap) {
     SIMD_CAP.store(cap as u8, Ordering::Relaxed);
+}
+
+/// Per-process cap (bytes) on the size of a DP scratch buffer that the thread-local
+/// `DP_MEM_CACHE` retains between alignments. `usize::MAX` is a sentinel for "not yet
+/// resolved": on first use it is initialized from `RAMMAP_DP_CACHE_CAP_MB` (megabytes)
+/// or [`DEFAULT_DP_CACHE_CAP_MB`]. [`set_dp_cache_cap_mb`] overrides it at runtime.
+static DP_CACHE_CAP_BYTES: AtomicUsize = AtomicUsize::new(usize::MAX);
+
+/// Default per-thread DP cache retention cap, in megabytes, when neither
+/// [`set_dp_cache_cap_mb`] nor `RAMMAP_DP_CACHE_CAP_MB` is set.
+pub const DEFAULT_DP_CACHE_CAP_MB: usize = 128;
+
+/// Set the per-process cap, in megabytes, on the DP scratch buffer that each worker
+/// thread's `DP_MEM_CACHE` retains between alignments. Buffers larger than the cap are
+/// freed back to the OS on drop instead of cached, bounding peak RSS at high thread
+/// counts (the minimap2 `cap_kalloc` analog). `0` disables the cap entirely, restoring
+/// unbounded high-water-mark caching.
+///
+/// Overrides both the [`DEFAULT_DP_CACHE_CAP_MB`] default and the `RAMMAP_DP_CACHE_CAP_MB`
+/// environment variable for all subsequent alignments on every thread. Process-global,
+/// like [`set_simd_cap`]; call once during setup.
+pub fn set_dp_cache_cap_mb(mb: usize) {
+    DP_CACHE_CAP_BYTES.store(mb.saturating_mul(1 << 20).min(usize::MAX - 1), Ordering::Relaxed);
+}
+
+/// Resolve the current DP cache cap in bytes (`0` = no cap), initializing from
+/// `RAMMAP_DP_CACHE_CAP_MB` (or the default) on first use.
+#[inline]
+pub(crate) fn dp_cache_cap_bytes() -> usize {
+    let v = DP_CACHE_CAP_BYTES.load(Ordering::Relaxed);
+    if v != usize::MAX {
+        return v;
+    }
+    // First use with no explicit override: derive from the environment (or default).
+    // Idempotent under races — every thread computes the same value.
+    let mb = std::env::var("RAMMAP_DP_CACHE_CAP_MB")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_DP_CACHE_CAP_MB);
+    let bytes = mb.saturating_mul(1 << 20).min(usize::MAX - 1);
+    DP_CACHE_CAP_BYTES.store(bytes, Ordering::Relaxed);
+    bytes
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -122,6 +164,26 @@ mod tests {
     use super::dual::{extend_dual_affine2_impl, extend_dual_affine41_impl, extend_dual_affine_avx2_fn, extend_dual_affine_avx512_fn};
     #[cfg(target_arch = "aarch64")]
     use super::dual::extend_dual_affine_neon_impl;
+
+    #[test]
+    fn test_dp_cache_cap_setter() {
+        // Process-global; save and restore so we don't perturb other tests. The
+        // cap only changes whether oversized buffers are cached vs freed — it is
+        // correctness-neutral, so a transient value here can't affect concurrent
+        // DP tests' results.
+        let saved = DP_CACHE_CAP_BYTES.load(Ordering::Relaxed);
+
+        set_dp_cache_cap_mb(64);
+        assert_eq!(dp_cache_cap_bytes(), 64 << 20);
+
+        set_dp_cache_cap_mb(0); // 0 disables the cap entirely
+        assert_eq!(dp_cache_cap_bytes(), 0);
+
+        set_dp_cache_cap_mb(DEFAULT_DP_CACHE_CAP_MB);
+        assert_eq!(dp_cache_cap_bytes(), DEFAULT_DP_CACHE_CAP_MB << 20);
+
+        DP_CACHE_CAP_BYTES.store(saved, Ordering::Relaxed);
+    }
 
     #[test]
     fn test_scalar_dual_affine() {

--- a/rammap-core/src/lib.rs
+++ b/rammap-core/src/lib.rs
@@ -6,4 +6,4 @@ pub mod fasta;
 pub use api::{Aligner, Mapping, MapResult, MapOpts, Preset, Strand, CigarOp};
 pub use api::{dp_align, dp_global, dp_local, dp_extension, DpScoring, DpAlignment, encode_nt4};
 // Runtime knob for the per-thread DP scratch-cache retention cap (peak-RSS control).
-pub use align::dp::{set_dp_cache_cap_mb, DEFAULT_DP_CACHE_CAP_MB};
+pub use align::dp::{set_dp_cache_cap_mb, DEFAULT_DP_CACHE_CAP_MB, DP_CACHE_UNBOUNDED};

--- a/rammap-core/src/lib.rs
+++ b/rammap-core/src/lib.rs
@@ -5,3 +5,5 @@ pub mod fasta;
 // Convenience re-exports for library users
 pub use api::{Aligner, Mapping, MapResult, MapOpts, Preset, Strand, CigarOp};
 pub use api::{dp_align, dp_global, dp_local, dp_extension, DpScoring, DpAlignment, encode_nt4};
+// Runtime knob for the per-thread DP scratch-cache retention cap (peak-RSS control).
+pub use align::dp::{set_dp_cache_cap_mb, DEFAULT_DP_CACHE_CAP_MB};


### PR DESCRIPTION
## Problem

The thread-local `DP_MEM_CACHE` (`rammap-core/src/align/dp/common.rs`) keeps each worker thread's **high-water-mark** DP scratch buffer alive for the lifetime of the run, to avoid repeated large mmap/munmap. Because the splice DP is **unbanded**, a single large gap-fill segment needs `O((qlen+tlen)·min(qlen,tlen))` bytes — hundreds of MB for the occasional read with a big unaligned gap. That one-off spike is then pinned per thread forever, so at high thread counts the sum dominates peak RSS.

Instrumenting the cache on a real workload (80k human PacBio-HiFi reads, splice index, 48 threads) showed per-thread DP-buffer HWMs of 300–984 MB, while only 39 of 578 distinct buffers exceeded 128 MB — i.e. a handful of outliers set a huge per-thread floor.

## Fix

Free DP buffers larger than a cap back to the OS on `drop` instead of caching them. The common case (almost all buffers well under the cap) stays cached and churn-free; only the rare giant buffers reallocate. This is the same bound minimap2 applies to its `km` arena via `cap_kalloc`. The DP computation is untouched — purely the post-use disposition of the scratch buffer changes, so alignment output is bit-identical.

The cap is adjustable three ways (state + setter in `align/dp/mod.rs`, mirroring `set_simd_cap`):

- **Default:** `rammap::DEFAULT_DP_CACHE_CAP_MB` = **128 MB** (one const).
- **Env var:** `RAMMAP_DP_CACHE_CAP_MB=<mb>` at runtime, no recompile (`0` disables the cap).
- **Programmatic:** `rammap::set_dp_cache_cap_mb(mb)` — set from code (e.g. an embedding consumer like oarfish); overrides default + env for all subsequent alignments on every thread. `0` disables.

## Measured impact (oarfish genome mode, 80k human PacBio-HiFi, 48 threads)

| cap | peak RSS | wall |
|---|---|---|
| uncapped (before) | 30.1 GB | 53 s |
| 64 MB | 23.7 GB | 59 s |
| **128 MB (default)** | **24.0 GB** (−20%) | 57 s |
| 256 MB | 25.2 GB | 58 s |
| minimap2 (reference) | 23.5 GB | 85 s |

Alignment output bit-identical before/after (52,996 unique alignments; downstream quant cosine-similarity 1.0, max diff 5.5e-15). `cargo test -p rammap-core` passes (109 tests + 4 doc-tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)