### PR TITLE
Index/Reference handling improvements, and add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Rust build artifacts (workspace-wide; Cargo.lock IS committed — this is a binary crate)
+/target
+**/target
+
+# wasm-pack build output (generated at repo root by scripts/build-wasm, see docs/wasm.md)
+/pkg
+
+# Editors / IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS cruft
+.DS_Store
+Thumbs.db
+
+# Local cargo config overrides (keep the committed .cargo/config.toml, ignore personal overrides)
+.cargo/config.local.toml

--- a/rammap-core/src/align/index.rs
+++ b/rammap-core/src/align/index.rs
@@ -389,6 +389,27 @@ impl Index {
     /// .mmi format magic: "MMI..02"
     const MINIMAP2_INDEX_MAGIC: &'static [u8; 4] = b"MMI\x02";
 
+    /// Peek at a file's leading 4 bytes to detect a binary index (RMMI or minimap2
+    /// `.mmi`), independent of file extension. Callers deciding whether to load a
+    /// pre-built index or build a new one from a sequence file should not rely on
+    /// extension alone: a real minimap2/rammap index saved under a non-standard name
+    /// (e.g. `.mm2` instead of `.mmi`) is otherwise silently misread as sequence
+    /// input, producing a bogus index built from the raw index bytes with no error.
+    /// Returns false on any read error, or for the legacy no-magic bincode format
+    /// (which can't be distinguished from arbitrary binary data by sniffing alone —
+    /// that format still needs the extension-based check as a fallback).
+    pub fn sniff_is_index_file(path: &str) -> bool {
+        let mut f = match File::open(path) {
+            Ok(f) => f,
+            Err(_) => return false,
+        };
+        let mut magic = [0u8; 4];
+        if f.read_exact(&mut magic).is_err() {
+            return false;
+        }
+        &magic == RMMI_MAGIC || &magic == Self::MINIMAP2_INDEX_MAGIC
+    }
+
     /// Load the next index part from a reader. Returns None on EOF.
     /// Detects RMMI (bincode-serialized), MMI\2 (.mmi binary layout), or
     /// legacy no-magic bincode formats.

--- a/rammap-core/src/fasta/reader.rs
+++ b/rammap-core/src/fasta/reader.rs
@@ -437,6 +437,28 @@ pub fn parse_fasta_bytes(data: &[u8]) -> io::Result<Vec<(String, Vec<u8>)>> {
         return Ok(sequences);
     }
 
+    // The streaming reader (Reader::detect_format) requires the first byte to be
+    // '>' before accepting input as FASTA. This mmap/batch path used to skip
+    // forward to the first '>' *anywhere* in the buffer instead of checking the
+    // first byte, which meant any non-FASTA binary file containing a stray 0x3E
+    // byte (near-guaranteed for any file of a few hundred bytes or more — e.g. a
+    // wrong path, a corrupted download, or an index file with an unrecognized
+    // extension that fell through the index/sequence-file dispatch) was silently
+    // "parsed" as one bogus sequence with binary garbage as its name, with no
+    // error at all. Enforce the same first-byte check here for consistency.
+    if data[0] != b'>' {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "not a valid FASTA file: expected '>' as the first byte, found {:?}. \
+                 Check that the correct file was provided — this is not a FASTA/FASTQ \
+                 file, and if it's meant to be a pre-built index it may have an \
+                 unrecognized extension (expected .mmi/.idx/.rmmi).",
+                data[0] as char
+            ),
+        ));
+    }
+
     // Use memchr for fast newline scanning
     let mut pos = 0;
     let len = data.len();

--- a/rammap/src/main.rs
+++ b/rammap/src/main.rs
@@ -797,7 +797,12 @@ fn run(cli: AlignArgs) -> anyhow::Result<()> {
     // ─── Build index parts iterator ───
     // Each iteration yields one Index part. For small references or large batch_size,
     // this will be a single iteration (matching current behavior exactly).
-    let is_idx_file = target_path.ends_with(".mmi") || target_path.ends_with(".idx") || target_path.ends_with(".rmmi");
+    // Extension is just a naming convention and not always reliable (e.g. a real
+    // minimap2/rammap index saved under a non-standard name) — fall back to sniffing
+    // the file's magic bytes so a mis-named index isn't silently misread as sequence
+    // input to build a new (bogus) index from.
+    let is_idx_file = target_path.ends_with(".mmi") || target_path.ends_with(".idx") || target_path.ends_with(".rmmi")
+        || Index::sniff_is_index_file(target_path);
     let mut n_parts = 0usize;
     let mut sam_header_written = false;
     let split_prefix = cli.split_prefix.clone();


### PR DESCRIPTION
Currently if an index file isn't named `.mmi`, `.idx`, .`rmmi` rammap assumes the file is a FASTA leading to strange behaviours, this PR adds a magic-byte check for mm2 indexes and checks for `>` as the first byte in input index FASTAs to avoid strangeness, also exits with a clearer error if `>` is not present.

Also added a `.gitignore` for my own sanity :)